### PR TITLE
Use :forbidden for unauthorized access

### DIFF
--- a/app/controllers/users/followings_controller.rb
+++ b/app/controllers/users/followings_controller.rb
@@ -25,7 +25,7 @@ module Users
     end
 
     def authorize!
-      head :unauthorized unless current_user == @user
+      head :forbidden unless current_user == @user
     end
   end
 end

--- a/app/controllers/users/likes_controller.rb
+++ b/app/controllers/users/likes_controller.rb
@@ -25,7 +25,7 @@ module Users
     end
 
     def authorize!
-      head :unauthorized unless current_user == @user
+      head :forbidden unless current_user == @user
     end
   end
 end

--- a/spec/controllers/users/followings_controller_spec.rb
+++ b/spec/controllers/users/followings_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Users::FollowingsController, type: :controller do
 
       it "requires authorization" do
         post :create, user_id: other_user, id: user
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "adds the user to current user's followings" do
@@ -44,7 +44,7 @@ RSpec.describe Users::FollowingsController, type: :controller do
 
       it "requires authorization" do
         delete :destroy, user_id: other_user, id: user
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "removes the user from current user's followings" do

--- a/spec/controllers/users/likes_controller_spec.rb
+++ b/spec/controllers/users/likes_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Users::LikesController, type: :controller do
 
       it "requires authorization" do
         post :create, user_id: other_user, id: story
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "adds the story to the user's liked stories" do
@@ -44,7 +44,7 @@ RSpec.describe Users::LikesController, type: :controller do
 
       it "requires authorization" do
         delete :destroy, user_id: other_user, id: story
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "removes the story from current user's liked stories" do


### PR DESCRIPTION
http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2 의 설명을 보면 `:unauthorized`는 unauthenticated의 의미에 더 가깝기 때문에, credential은 확인했지만 권한이 없는 경우엔 `:forbidden`을 쓰는 것이 맞다는 결론에 도달함

http://stackoverflow.com/a/6937030
